### PR TITLE
Fix: #12. Replace tab key when pressed editor.

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -127,7 +127,12 @@ var editor = CodeMirror.fromTextArea(myTextarea, {
   lineNumbers: true,
   styleSelected: true,
   mode: "text/x-yaml",
-  theme: "darcula"
+  theme: "darcula",
+  extraKeys: {
+    "Tab": function(cm){
+      cm.replaceSelection("   " , "end");
+    }
+  }
 });
 
 var counter = Date.now();


### PR DESCRIPTION
## This PR

replaces in-editor tabs to 2 spaces.