### PR TITLE
Fix: #31 Ignore `url` parameter in location

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -43,7 +43,7 @@ async function parseText() {
 }
 
 async function lintSpec(oas) {
-  const lint = await api_oas_checker.parse(oas, window.location.href + '/spectral.yml');
+  const lint = await api_oas_checker.parse(oas, location.origin + location.pathname + '/spectral.yml');
   console.log("lint: ", lint);
 
   // mark errored lines


### PR DESCRIPTION
## This PR 

fixes #31 replacing window.location.href with

location.origin + location.pathname