### PR TITLE
Cleanup existing rules.

### DIFF
--- a/rules/casing.yml
+++ b/rules/casing.yml
@@ -2,7 +2,6 @@ rules:
   paths-kebab-case:
     description: |
       Paths should be kebab-case.
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#usare-parole-separate-da-trattino-per-i-path-kebab-case
     message: '{{property}} is not kebab-case: {{error}}'
     severity: warn
     recommended: true

--- a/rules/metadata.yml
+++ b/rules/metadata.yml
@@ -26,7 +26,7 @@ rules:
 
   has-x-summary:
     description: >-
-      API must have an one-liner summary field in x-summary {{path}}
+      API must have an one-liner summary field in #/info/x-summary
     given: $
     severity: error
     recommended: true
@@ -39,7 +39,7 @@ rules:
 
   has-termsOfService:
     description: >-
-      API MUST reference the URL of the Terms of Service {{path}}
+      API MUST reference the URL of the Terms of Service in #/info/termsOfService
     given: $
     severity: error
     recommended: true
@@ -52,7 +52,7 @@ rules:
 
   has-contact:
     description: >-
-      API MUST reference a contact, either url or email: {{path}}
+      API MUST reference a contact, either url or email in #/info/contact
     given: $
     severity: error
     recommended: true
@@ -65,7 +65,7 @@ rules:
 
   has-x-api-id:
     description: >-
-      API must have an unique identifier in x-api-id {{path}}
+      API must have an unique identifier in x-api-id in #/info/x-api-id
     given: $
     severity: error
     recommended: true

--- a/rules/numbers.yml
+++ b/rules/numbers.yml
@@ -1,37 +1,29 @@
+#
+# Here we use yaml merge keys to reuse existing rules.
+#
 rules:
-  number-format:
-    description: Number must specify a format.
+  number-format: &number-format
+    description: Schema of type number or integer must specify a format.
     message: >-
-      Schema of type number must specify a format. {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
+      Schema of type number or integer must specify a format. {{path}}
     formats:
     - oas3
     severity: error
     recommended: true
-    given: >
+    given: >-
       $.[?(@.type=="number")]
     then:
       field: format
       function: truthy
   integer-format:
-    description: Integer must specify a format.
-    message: >-
-      Schema of type integer must specify a format. {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
-    formats:
-    - oas3
-    severity: error
-    recommended: true
+    <<: *number-format
     given: >
       $.[?(@.type=="integer")]
-    then:
-      field: format
-      function: truthy
+
   allowed-integer-format:
-    description: Integer format should be in the table.
+    description: Integer format is not valid.
     message: >-
-      integer format is "{{value}}", expected one of [int32, int64]. {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
+      Type format is "{{value}}", expected one of [int32, int64]. {{path}}
     formats:
     - oas3
     severity: hint
@@ -46,10 +38,9 @@ rules:
         - int32
         - int64
   allowed-number-format:
-    description: Integer format should be in the table.
+    description: Number format is not valid.
     message: >-
-      number format is "{{value}}", expected one of [decimal32, decimal64, decimal128, float, double]. {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
+      Type format is "{{value}}", expected one of [decimal32, decimal64, decimal128, float, double]. {{path}}
     formats:
     - oas3
     severity: hint

--- a/rules/patch.yml
+++ b/rules/patch.yml
@@ -1,16 +1,10 @@
-#
-# See technical recommendations on Italian Guidelines:
-#
-# https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#raccomandazioni-tecniche-per-rest
-#
-# extends: spectral:oas
 rules:
   patch-media-type:
     description: |-
       application/json is not an appropriate media-type for PATCH.
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#usare-lo-schema-problem-json-per-le-risposte-di-errore
     message: >-
       application/json is not an appropriate media-type for PATCH. {{path}}
+      See https://www.rfc-editor.org/errata/eid3169
     formats:
     - oas3
     severity: error

--- a/rules/problem.yml
+++ b/rules/problem.yml
@@ -1,8 +1,8 @@
 rules:
   use-problem-json-for-errors:
-    description: >-
+    description: |-
       Error responses should support [RFC 7807](https://tools.ietf.org/html/rfc6648) 
-    message: >-
+    message: |-
       Error responses should support [RFC 7807](https://tools.ietf.org/html/rfc6648) in {{path}}.
     formats:
       - oas3
@@ -17,12 +17,12 @@ rules:
         - application/problem+json  
 
   use-problem-schema:
-    description: >-
+    description: |-
       WARN: This rule is under implementation.
-      Your problem schema doesn't seem to match RFC7807. Are you sure its' ok?
+      Your problem schema doesn't seem to match RFC7807. Are you sure it is ok?
       See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#usare-lo-schema-problem-json-per-le-risposte-di-errore
-    message: >-
-            Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: |-
+      Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
     formats:
     - oas3
     severity: hint
@@ -45,10 +45,10 @@ rules:
 
   hint-problem-schema:
     description: >-
-      Your problem schema doesn't seem to match RFC7807. Are you sure its' ok?
+      Your problem schema doesn't seem to match RFC7807. Are you sure it is ok?
       See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#usare-lo-schema-problem-json-per-le-risposte-di-errore
-    message: >-
-            Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: |-
+      Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
     formats:
     - oas3
     severity: hint

--- a/rules/ratelimit.yml
+++ b/rules/ratelimit.yml
@@ -4,7 +4,6 @@ rules:
       APIs should use Retry-After on 429 and 503 responses.
     message: >-
       Missing ratelimit header: {{property}} in {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/robustezza.html#segnalare-raggiunti-limiti-di-utilizzo
     formats:
       - oas3
     severity: warn
@@ -19,7 +18,6 @@ rules:
       APIs should use ratelimit headers at least on successful responses.
     message: >-
       Missing ratelimit headers. {{property}} {{error}} {{path}}
-      See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/robustezza.html#segnalare-raggiunti-limiti-di-utilizzo
     formats:
       - oas3
     severity: warn

--- a/rules/tests/metadata-test.snapshot
+++ b/rules/tests/metadata-test.snapshot
@@ -4,10 +4,10 @@ OpenAPI 3.x detected
   3:5   error  servers-description  Server #/servers/0 must have a description.
   9:10  error  servers-use-https    Non-sandbox url  http://ko.example must match the pattern '^https://.*'. Add `x-sandbox: true` to declare the server as a sandbox.
  11:10  error  servers-use-https    Non-sandbox url  http://ko.sandbox.examle must match the pattern '^https://.*'. Add `x-sandbox: true` to declare the server as a sandbox.
-  14:6  error  has-contact          API MUST reference a contact, either url or email: {{path}}
-  14:6  error  has-termsOfService   API MUST reference the URL of the Terms of Service {{path}}
-  14:6  error  has-x-api-id         API must have an unique identifier in x-api-id {{path}}
-  14:6  error  has-x-summary        API must have an one-liner summary field in x-summary {{path}}
+  14:6  error  has-contact          API MUST reference a contact, either url or email in #/info/contact
+  14:6  error  has-termsOfService   API MUST reference the URL of the Terms of Service in #/info/termsOfService
+  14:6  error  has-x-api-id         API must have an unique identifier in x-api-id in #/info/x-api-id
+  14:6  error  has-x-summary        API must have an one-liner summary field in #/info/x-summary
 
 ✖ 7 problems (7 errors, 0 warnings, 0 infos, 0 hints)
 

--- a/rules/tests/numbers-test.snapshot
+++ b/rules/tests/numbers-test.snapshot
@@ -1,13 +1,13 @@
 OpenAPI 3.x detected
 
 /code/rules/tests/numbers-test.yml
-  6:17   hint  allowed-integer-format  integer format is "bad", expected one of [int32, int64]. #/components/schemas/ko_Integer_bad1/schema/format See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 10:17   hint  allowed-number-format   number format is "bad", expected one of [decimal32, decimal64, decimal128, float, double]. #/components/schemas/ko_Number_bad1/schema/format See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 12:14  error  number-format           Schema of type number must specify a format. #/components/schemas/ko_Number/schema See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 17:17   hint  allowed-number-format   number format is "int32", expected one of [decimal32, decimal64, decimal128, float, double]. #/components/schemas/Number/schema/format See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 19:14  error  integer-format          Schema of type integer must specify a format. #/components/schemas/ko_Integer/schema See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 34:22   hint  allowed-number-format   number format is "int32", expected one of [decimal32, decimal64, decimal128, float, double]. #/paths/~1number-ok/put/requestBody/content/application~1json-patch+json/schema/format See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
- 48:19  error  number-format           Schema of type number must specify a format. #/paths/~1number-ko/put/requestBody/content/application~1json-patch+json/schema See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/regole-comuni-rest-soap.html#definire-format-quando-si-usano-i-tipi-number-ed-integer
+  6:17   hint  allowed-integer-format  Type format is "bad", expected one of [int32, int64]. #/components/schemas/ko_Integer_bad1/schema/format
+ 10:17   hint  allowed-number-format   Type format is "bad", expected one of [decimal32, decimal64, decimal128, float, double]. #/components/schemas/ko_Number_bad1/schema/format
+ 12:14  error  number-format           Schema of type number or integer must specify a format. #/components/schemas/ko_Number/schema
+ 17:17   hint  allowed-number-format   Type format is "int32", expected one of [decimal32, decimal64, decimal128, float, double]. #/components/schemas/Number/schema/format
+ 19:14  error  integer-format          Schema of type number or integer must specify a format. #/components/schemas/ko_Integer/schema
+ 34:22   hint  allowed-number-format   Type format is "int32", expected one of [decimal32, decimal64, decimal128, float, double]. #/paths/~1number-ok/put/requestBody/content/application~1json-patch+json/schema/format
+ 48:19  error  number-format           Schema of type number or integer must specify a format. #/paths/~1number-ko/put/requestBody/content/application~1json-patch+json/schema
 
 ✖ 7 problems (3 errors, 0 warnings, 0 infos, 4 hints)
 

--- a/rules/tests/patch-test.snapshot
+++ b/rules/tests/patch-test.snapshot
@@ -1,7 +1,7 @@
 OpenAPI 3.x detected
 
 /code/rules/tests/patch-test.yml
- 7:30  error  patch-media-type  application/json is not an appropriate media-type for PATCH. #/paths/~1ko-patch/patch/requestBody/content/application~1json
+ 7:30  error  patch-media-type  application/json is not an appropriate media-type for PATCH. #/paths/~1ko-patch/patch/requestBody/content/application~1json See https://www.rfc-editor.org/errata/eid3169
 
 ✖ 1 problem (1 error, 0 warnings, 0 infos, 0 hints)
 

--- a/rules/tests/ratelimit-test.snapshot
+++ b/rules/tests/ratelimit-test.snapshot
@@ -1,9 +1,9 @@
 OpenAPI 3.x detected
 
 /code/rules/tests/ratelimit-test.yml
- 35:19  warning  missing-ratelimit    Missing ratelimit headers. headers X-RateLimit-Limit and RateLimit-Limit cannot be both defined or both undefined #/paths/~1ko/get/responses/201/headers See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/robustezza.html#segnalare-raggiunti-limiti-di-utilizzo
- 39:19  warning  missing-retry-after  Missing ratelimit header: `headers.Retry-After` property  in #/paths/~1ko/get/responses/429/headers See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/robustezza.html#segnalare-raggiunti-limiti-di-utilizzo
- 42:19  warning  missing-retry-after  Missing ratelimit header: `headers.Retry-After` property  in #/paths/~1ko/get/responses/503/headers See https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/profili-di-interazione/robustezza.html#segnalare-raggiunti-limiti-di-utilizzo
+ 35:19  warning  missing-ratelimit    Missing ratelimit headers. headers X-RateLimit-Limit and RateLimit-Limit cannot be both defined or both undefined #/paths/~1ko/get/responses/201/headers
+ 39:19  warning  missing-retry-after  Missing ratelimit header: headers.Retry-After in #/paths/~1ko/get/responses/429/headers
+ 42:19  warning  missing-retry-after  Missing ratelimit header: headers.Retry-After in #/paths/~1ko/get/responses/503/headers
 
 ✖ 3 problems (0 errors, 3 warnings, 0 infos, 0 hints)
 


### PR DESCRIPTION
## This PR

- removes typos
- reuse part of the rules via anchors
- remove (temporarily) references to the preliminary guidelines because the new ones have been published